### PR TITLE
Fix debug tasks for hosts

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -42,8 +42,15 @@
     },
     {
       "label": "Debug: Excel Desktop",
-      "type": "npm",
-      "script": "start:desktop -- --app excel",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "start:desktop",
+        "--",
+        "--app",
+        "excel",
+      ],
       "dependsOn": [
         "Build (Development)"
       ],
@@ -56,8 +63,15 @@
     },
     {
       "label": "Debug: Outlook Desktop",
-      "type": "npm",
-      "script": "start:desktop -- --app outlook",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "start:desktop",
+        "--",
+        "--app",
+        "outlook",
+      ],
       "dependsOn": [
         "Build (Development)"
       ],
@@ -70,8 +84,15 @@
     },
     {
       "label": "Debug: PowerPoint Desktop",
-      "type": "npm",
-      "script": "start:desktop -- --app powerpoint",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "start:desktop",
+        "--",
+        "--app",
+        "powerpoint",
+      ],
       "dependsOn": [
         "Build (Development)"
       ],
@@ -84,8 +105,15 @@
     },
     {
       "label": "Debug: Word Desktop",
-      "type": "npm",
-      "script": "start:desktop -- --app word",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "start:desktop",
+        "--",
+        "--app",
+        "word",
+      ],
       "dependsOn": [
         "Build (Development)"
       ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,186 +1,186 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-      {
-        "label": "Build (Development)",
-        "type": "npm",
-        "script": "build:dev",
-        "group": {
-          "kind": "build",
-          "isDefault": true
-        },
-        "presentation": {
-          "clear": true,
-          "panel": "shared",
-          "showReuseMessage": false
-        }
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Build (Development)",
+      "type": "npm",
+      "script": "build:dev",
+      "group": {
+        "kind": "build",
+        "isDefault": true
       },
-      {
-        "label": "Build (Production)",
-        "type": "npm",
-        "script": "build",
-        "group": "build",
-        "presentation": {
-          "clear": true,
-          "panel": "shared",
-          "showReuseMessage": false
-        }
-      },
-      {
-        "label": "Debug: Desktop",
-        "type": "npm",
-        "script": "start",
-        "dependsOn": [
-          "Build (Development)"
-        ],
-        "dependsOrder": "sequence",
-        "presentation": {
-          "clear": true,
-          "panel": "dedicated"
-        },
-        "problemMatcher": []
-      },
-      {
-        "label": "Debug: Excel Desktop",
-        "type": "shell",
-        "command": "npm",
-        "args": [
-          "run",
-          "start:desktop",
-          "--",
-          "--app",
-          "excel"
-        ],
-        "dependsOn": [
-          "Build (Development)"
-        ],
-        "dependsOrder": "sequence",
-        "presentation": {
-          "clear": true,
-          "panel": "dedicated"
-        },
-        "problemMatcher": []
-      },
-      {
-        "label": "Debug: Outlook Desktop",
-        "type": "shell",
-        "command": "npm",
-        "args": [
-          "run",
-          "start:desktop",
-          "--",
-          "--app",
-          "outlook"
-        ],
-        "dependsOn": [
-          "Build (Development)"
-        ],
-        "dependsOrder": "sequence",
-        "presentation": {
-          "clear": true,
-          "panel": "dedicated"
-        },
-        "problemMatcher": []
-      },
-      {
-        "label": "Debug: PowerPoint Desktop",
-        "type": "shell",
-        "command": "npm",
-        "args": [
-          "run",
-          "start:desktop",
-          "--",
-          "--app",
-          "powerpoint"
-        ],
-        "dependsOn": [
-          "Build (Development)"
-        ],
-        "dependsOrder": "sequence",
-        "presentation": {
-          "clear": true,
-          "panel": "dedicated"
-        },
-        "problemMatcher": []
-      },
-      {
-        "label": "Debug: Word Desktop",
-        "type": "shell",
-        "command": "npm",
-        "args": [
-          "run",
-          "start:desktop",
-          "--",
-          "--app",
-          "word"
-        ],
-        "dependsOn": [
-          "Build (Development)"
-        ],
-        "dependsOrder": "sequence",
-        "presentation": {
-          "clear": true,
-          "panel": "dedicated"
-        },
-        "problemMatcher": []
-      },
-      {
-        "label": "Dev Server",
-        "type": "npm",
-        "script": "dev-server",
-        "presentation": {
-          "clear": true,
-          "panel": "dedicated"
-        },
-        "problemMatcher": []
-      },
-      {
-        "label": "Install",
-        "type": "npm",
-        "script": "install",
-        "presentation": {
-          "clear": true,
-          "panel": "shared",
-          "showReuseMessage": false
-        },
-        "problemMatcher": []
-      },
-      {
-        "label": "Lint: Check for problems",
-        "type": "npm",
-        "script": "lint",
-        "problemMatcher": [
-          "$eslint-stylish"
-        ]
-      },
-      {
-        "label": "Lint: Fix all auto-fixable problems",
-        "type": "npm",
-        "script": "lint:fix",
-        "problemMatcher": [
-          "$eslint-stylish"
-        ]
-      },
-      {
-        "label": "Stop Debug",
-        "type": "npm",
-        "script": "stop",
-        "presentation": {
-          "clear": true,
-          "panel": "shared",
-          "showReuseMessage": false
-        },
-        "problemMatcher": []
-      },
-      {
-        "label": "Watch",
-        "type": "npm",
-        "script": "watch",
-        "presentation": {
-          "clear": true,
-          "panel": "dedicated"
-        },
-        "problemMatcher": []
+      "presentation": {
+        "clear": true,
+        "panel": "shared",
+        "showReuseMessage": false
       }
-    ]
-  }
+    },
+    {
+      "label": "Build (Production)",
+      "type": "npm",
+      "script": "build",
+      "group": "build",
+      "presentation": {
+        "clear": true,
+        "panel": "shared",
+        "showReuseMessage": false
+      }
+    },
+    {
+      "label": "Debug: Desktop",
+      "type": "npm",
+      "script": "start",
+      "dependsOn": [
+        "Build (Development)"
+      ],
+      "dependsOrder": "sequence",
+      "presentation": {
+        "clear": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Debug: Excel Desktop",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "start:desktop",
+        "--",
+        "--app",
+        "excel"
+      ],
+      "dependsOn": [
+        "Build (Development)"
+      ],
+      "dependsOrder": "sequence",
+      "presentation": {
+        "clear": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Debug: Outlook Desktop",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "start:desktop",
+        "--",
+        "--app",
+        "outlook"
+      ],
+      "dependsOn": [
+        "Build (Development)"
+      ],
+      "dependsOrder": "sequence",
+      "presentation": {
+        "clear": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Debug: PowerPoint Desktop",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "start:desktop",
+        "--",
+        "--app",
+        "powerpoint"
+      ],
+      "dependsOn": [
+        "Build (Development)"
+      ],
+      "dependsOrder": "sequence",
+      "presentation": {
+        "clear": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Debug: Word Desktop",
+      "type": "shell",
+      "command": "npm",
+      "args": [
+        "run",
+        "start:desktop",
+        "--",
+        "--app",
+        "word"
+      ],
+      "dependsOn": [
+        "Build (Development)"
+      ],
+      "dependsOrder": "sequence",
+      "presentation": {
+        "clear": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Dev Server",
+      "type": "npm",
+      "script": "dev-server",
+      "presentation": {
+        "clear": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Install",
+      "type": "npm",
+      "script": "install",
+      "presentation": {
+        "clear": true,
+        "panel": "shared",
+        "showReuseMessage": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Lint: Check for problems",
+      "type": "npm",
+      "script": "lint",
+      "problemMatcher": [
+        "$eslint-stylish"
+      ]
+    },
+    {
+      "label": "Lint: Fix all auto-fixable problems",
+      "type": "npm",
+      "script": "lint:fix",
+      "problemMatcher": [
+        "$eslint-stylish"
+      ]
+    },
+    {
+      "label": "Stop Debug",
+      "type": "npm",
+      "script": "stop",
+      "presentation": {
+        "clear": true,
+        "panel": "shared",
+        "showReuseMessage": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Watch",
+      "type": "npm",
+      "script": "watch",
+      "presentation": {
+        "clear": true,
+        "panel": "dedicated"
+      },
+      "problemMatcher": []
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,186 +1,186 @@
 {
-  "version": "2.0.0",
-  "tasks": [
-    {
-      "label": "Build (Development)",
-      "type": "npm",
-      "script": "build:dev",
-      "group": {
-        "kind": "build",
-        "isDefault": true
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "Build (Development)",
+        "type": "npm",
+        "script": "build:dev",
+        "group": {
+          "kind": "build",
+          "isDefault": true
+        },
+        "presentation": {
+          "clear": true,
+          "panel": "shared",
+          "showReuseMessage": false
+        }
       },
-      "presentation": {
-        "clear": true,
-        "panel": "shared",
-        "showReuseMessage": false
+      {
+        "label": "Build (Production)",
+        "type": "npm",
+        "script": "build",
+        "group": "build",
+        "presentation": {
+          "clear": true,
+          "panel": "shared",
+          "showReuseMessage": false
+        }
+      },
+      {
+        "label": "Debug: Desktop",
+        "type": "npm",
+        "script": "start",
+        "dependsOn": [
+          "Build (Development)"
+        ],
+        "dependsOrder": "sequence",
+        "presentation": {
+          "clear": true,
+          "panel": "dedicated"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Debug: Excel Desktop",
+        "type": "shell",
+        "command": "npm",
+        "args": [
+          "run",
+          "start:desktop",
+          "--",
+          "--app",
+          "excel"
+        ],
+        "dependsOn": [
+          "Build (Development)"
+        ],
+        "dependsOrder": "sequence",
+        "presentation": {
+          "clear": true,
+          "panel": "dedicated"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Debug: Outlook Desktop",
+        "type": "shell",
+        "command": "npm",
+        "args": [
+          "run",
+          "start:desktop",
+          "--",
+          "--app",
+          "outlook"
+        ],
+        "dependsOn": [
+          "Build (Development)"
+        ],
+        "dependsOrder": "sequence",
+        "presentation": {
+          "clear": true,
+          "panel": "dedicated"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Debug: PowerPoint Desktop",
+        "type": "shell",
+        "command": "npm",
+        "args": [
+          "run",
+          "start:desktop",
+          "--",
+          "--app",
+          "powerpoint"
+        ],
+        "dependsOn": [
+          "Build (Development)"
+        ],
+        "dependsOrder": "sequence",
+        "presentation": {
+          "clear": true,
+          "panel": "dedicated"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Debug: Word Desktop",
+        "type": "shell",
+        "command": "npm",
+        "args": [
+          "run",
+          "start:desktop",
+          "--",
+          "--app",
+          "word"
+        ],
+        "dependsOn": [
+          "Build (Development)"
+        ],
+        "dependsOrder": "sequence",
+        "presentation": {
+          "clear": true,
+          "panel": "dedicated"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Dev Server",
+        "type": "npm",
+        "script": "dev-server",
+        "presentation": {
+          "clear": true,
+          "panel": "dedicated"
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Install",
+        "type": "npm",
+        "script": "install",
+        "presentation": {
+          "clear": true,
+          "panel": "shared",
+          "showReuseMessage": false
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Lint: Check for problems",
+        "type": "npm",
+        "script": "lint",
+        "problemMatcher": [
+          "$eslint-stylish"
+        ]
+      },
+      {
+        "label": "Lint: Fix all auto-fixable problems",
+        "type": "npm",
+        "script": "lint:fix",
+        "problemMatcher": [
+          "$eslint-stylish"
+        ]
+      },
+      {
+        "label": "Stop Debug",
+        "type": "npm",
+        "script": "stop",
+        "presentation": {
+          "clear": true,
+          "panel": "shared",
+          "showReuseMessage": false
+        },
+        "problemMatcher": []
+      },
+      {
+        "label": "Watch",
+        "type": "npm",
+        "script": "watch",
+        "presentation": {
+          "clear": true,
+          "panel": "dedicated"
+        },
+        "problemMatcher": []
       }
-    },
-    {
-      "label": "Build (Production)",
-      "type": "npm",
-      "script": "build",
-      "group": "build",
-      "presentation": {
-        "clear": true,
-        "panel": "shared",
-        "showReuseMessage": false
-      }
-    },
-    {
-      "label": "Debug: Desktop",
-      "type": "npm",
-      "script": "start",
-      "dependsOn": [
-        "Build (Development)"
-      ],
-      "dependsOrder": "sequence",
-      "presentation": {
-        "clear": true,
-        "panel": "dedicated",
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Debug: Excel Desktop",
-      "type": "shell",
-      "command": "npm",
-      "args": [
-        "run",
-        "start:desktop",
-        "--",
-        "--app",
-        "excel",
-      ],
-      "dependsOn": [
-        "Build (Development)"
-      ],
-      "dependsOrder": "sequence",
-      "presentation": {
-        "clear": true,
-        "panel": "dedicated"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Debug: Outlook Desktop",
-      "type": "shell",
-      "command": "npm",
-      "args": [
-        "run",
-        "start:desktop",
-        "--",
-        "--app",
-        "outlook",
-      ],
-      "dependsOn": [
-        "Build (Development)"
-      ],
-      "dependsOrder": "sequence",
-      "presentation": {
-        "clear": true,
-        "panel": "dedicated"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Debug: PowerPoint Desktop",
-      "type": "shell",
-      "command": "npm",
-      "args": [
-        "run",
-        "start:desktop",
-        "--",
-        "--app",
-        "powerpoint",
-      ],
-      "dependsOn": [
-        "Build (Development)"
-      ],
-      "dependsOrder": "sequence",
-      "presentation": {
-        "clear": true,
-        "panel": "dedicated"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Debug: Word Desktop",
-      "type": "shell",
-      "command": "npm",
-      "args": [
-        "run",
-        "start:desktop",
-        "--",
-        "--app",
-        "word",
-      ],
-      "dependsOn": [
-        "Build (Development)"
-      ],
-      "dependsOrder": "sequence",
-      "presentation": {
-        "clear": true,
-        "panel": "dedicated"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Dev Server",
-      "type": "npm",
-      "script": "dev-server",
-      "presentation": {
-        "clear": true,
-        "panel": "dedicated"
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Install",
-      "type": "npm",
-      "script": "install",
-      "presentation": {
-        "clear": true,
-        "panel": "shared",
-        "showReuseMessage": false
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Lint: Check for problems",
-      "type": "npm",
-      "script": "lint",
-      "problemMatcher": [
-        "$eslint-stylish"
-      ]
-    },
-    {
-      "label": "Lint: Fix all auto-fixable problems",
-      "type": "npm",
-      "script": "lint:fix",
-      "problemMatcher": [
-        "$eslint-stylish"
-      ]
-    },
-    {
-      "label": "Stop Debug",
-      "type": "npm",
-      "script": "stop",
-      "presentation": {
-        "clear": true,
-        "panel": "shared",
-        "showReuseMessage": false
-      },
-      "problemMatcher": []
-    },
-    {
-      "label": "Watch",
-      "type": "npm",
-      "script": "watch",
-      "presentation": {
-        "clear": true,
-        "panel": "dedicated"
-      },
-      "problemMatcher": []
-    }
-  ]
-}
+    ]
+  }


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:

    If you build a new project and press F5 in VS Code, you will get an error and you won't be able to debug the add-in project. This fixes the tasks so that the launch a shell with arguments correctly and debug works out of the box.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
    If Yes, briefly describe what is impacted.
No.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
    If Yes, briefly describe what is impacted.
Yes, changes are to tasks.json.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
    If Yes, briefly describe what is impacted.
Yes. tasks.json.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
    If Yes, briefly describe what is impacted.
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:

    Describe manual testing done. 
