### PR TITLE
fix convert script for private registry

### DIFF
--- a/convertToSingleHost.js
+++ b/convertToSingleHost.js
@@ -271,42 +271,61 @@ async function modifyProjectForJSONManifest() {
   await deleteXMLManifestRelatedFiles();
 }
 
-/**
- * Modify the project so that it only supports a single host.
- * @param host The host to support.
- */
-modifyProjectForSingleHost(host).catch((err) => {
-  console.error(`Error modifying for single host: ${err instanceof Error ? err.message : err}`);
-  process.exitCode = 1;
-});
+async function main() {
 
-let manifestPath = "manifest.xml";
-
-if (host !== "outlook" || manifestType !== "json") {
-  // Remove things that are only relevant to JSON manifest
-  deleteJSONManifestRelatedFiles();
-  updatePackageJsonForXMLManifest();
-} else {
-  manifestPath = "manifest.json";
-  modifyProjectForJSONManifest().catch((err) => {
-    console.error(`Error modifying for JSON manifest: ${err instanceof Error ? err.message : err}`);
+  try {
+    /**
+     * Modify the project so that it only supports a single host.
+     * @param host The host to support.
+     */
+    await modifyProjectForSingleHost(host);
+  } catch (err) {
+    console.error(`Error modifying for single host: ${err instanceof Error ? err.message : err}`);
     process.exitCode = 1;
-  });
-}
-
-if (projectName) {
-  if (!appId) {
-    appId = "random";
+    return;
   }
 
-  // Modify the manifest to include the name and id of the project
-  const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d "${projectName}"`;
-  childProcess.exec(cmdLine, (error, stdout) => {
-    if (error) {
-      console.error(`Error updating the manifest: ${error}`);
+  let manifestPath = "manifest.xml";
+
+  if (host !== "outlook" || manifestType !== "json") {
+    // Remove things that are only relevant to JSON manifest
+    await deleteJSONManifestRelatedFiles();
+    await updatePackageJsonForXMLManifest();
+  } else {
+    manifestPath = "manifest.json";
+    try {
+      await modifyProjectForJSONManifest();
+    } catch (err) {
+      console.error(`Error modifying for JSON manifest: ${err instanceof Error ? err.message : err}`);
       process.exitCode = 1;
-    } else {
-      console.log(stdout);
+      return;
     }
-  });
+  }
+
+  if (projectName) {
+    if (!appId) {
+      appId = "random";
+    }
+
+    // Modify the manifest to include the name and id of the project
+    const cmdLine = `npx office-addin-manifest modify ${manifestPath} -g ${appId} -d "${projectName}"`;
+    const execEnv = { ...process.env };
+    delete execEnv.npm_config_registry;
+    await new Promise((resolve) => {
+      childProcess.exec(cmdLine, { env: execEnv }, (error, stdout) => {
+        if (error) {
+          console.error(`Error updating the manifest: ${error}`);
+          process.exitCode = 1;
+        } else {
+          console.log(stdout);
+        }
+        resolve();
+      });
+    });
+  }
 }
+
+main().catch((err) => {
+  console.error(`Unhandled error: ${err instanceof Error ? err.message : err}`);
+  process.exitCode = 1;
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -475,23 +475,23 @@
       }
     },
     "node_modules/@azure/identity/node_modules/@azure/msal-browser": {
-      "version": "5.17.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-browser/-/msal-browser-5.17.1.tgz",
-      "integrity": "sha1-EozjSq27IGyUDpnKXgzxldEsbfw=",
+      "version": "5.18.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-browser/-/msal-browser-5.18.0.tgz",
+      "integrity": "sha1-RGubQmeKIgQZ70MFT9/BOFWhLC4=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@azure/msal-common": "16.11.2"
+        "@azure/msal-common": "16.12.0"
       },
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@azure/identity/node_modules/@azure/msal-common": {
-      "version": "16.11.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-common/-/msal-common-16.11.2.tgz",
-      "integrity": "sha1-bLo7L5utC9sH7o37+nLv9Lo2nDA=",
+      "version": "16.12.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-common/-/msal-common-16.12.0.tgz",
+      "integrity": "sha1-XL1Y25GUj5I4LoxijzSlf0adOnQ=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -568,14 +568,14 @@
       }
     },
     "node_modules/@azure/msal-node": {
-      "version": "5.4.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-node/-/msal-node-5.4.2.tgz",
-      "integrity": "sha1-EeB7IuSZAznQzjMVTg7+pLLFUPo=",
+      "version": "5.5.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-node/-/msal-node-5.5.0.tgz",
+      "integrity": "sha1-1JivIxqllWZkKJve00fAVrX357M=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@azure/msal-common": "16.11.2",
+        "@azure/msal-common": "16.12.0",
         "jsonwebtoken": "^9.0.0"
       },
       "engines": {
@@ -619,9 +619,9 @@
       "peer": true
     },
     "node_modules/@azure/msal-node/node_modules/@azure/msal-common": {
-      "version": "16.11.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-common/-/msal-common-16.11.2.tgz",
-      "integrity": "sha1-bLo7L5utC9sH7o37+nLv9Lo2nDA=",
+      "version": "16.12.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-common/-/msal-common-16.12.0.tgz",
+      "integrity": "sha1-XL1Y25GUj5I4LoxijzSlf0adOnQ=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -657,16 +657,16 @@
       }
     },
     "node_modules/@azure/storage-common": {
-      "version": "12.4.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/storage-common/-/storage-common-12.4.1.tgz",
-      "integrity": "sha1-eMI6si3QTOJ7E9/omRtFtv3ts0U=",
+      "version": "12.5.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/storage-common/-/storage-common-12.5.0.tgz",
+      "integrity": "sha1-nbHWmPJu9LVqVKYABGp2XqG7oxY=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@azure/abort-controller": "^2.1.2",
         "@azure/core-auth": "^1.9.0",
-        "@azure/core-http-compat": "^2.2.0",
+        "@azure/core-http-compat": "^2.4.0",
         "@azure/core-rest-pipeline": "^1.24.0",
         "@azure/core-tracing": "^1.2.0",
         "@azure/core-util": "^1.11.0",
@@ -675,7 +675,7 @@
         "tslib": "^2.8.1"
       },
       "engines": {
-        "node": ">=20.0.0"
+        "node": ">=22.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2964,9 +2964,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "2.0.12",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@hono/node-server/-/node-server-2.0.12.tgz",
-      "integrity": "sha1-I4dshkDse5zHfdRXdYRksSBqEc0=",
+      "version": "2.1.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha1-wYI+G5rda90UgH+7/sObi4BhSyU=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5054,9 +5054,9 @@
       "dev": true
     },
     "node_modules/@microsoft/app-manifest": {
-      "version": "1.0.7",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/app-manifest/-/app-manifest-1.0.7.tgz",
-      "integrity": "sha1-0+sp26sVBEHWFTXcL8xieyXnsas=",
+      "version": "1.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/app-manifest/-/app-manifest-1.1.1.tgz",
+      "integrity": "sha1-w2NwblkrkH7nynrOKHIv/zftuBU=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5259,17 +5259,17 @@
       }
     },
     "node_modules/@microsoft/m365-spec-parser": {
-      "version": "0.2.14",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/m365-spec-parser/-/m365-spec-parser-0.2.14.tgz",
-      "integrity": "sha1-WA4PLBcQaQefiltl8RJOznDIYq8=",
+      "version": "0.3.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/m365-spec-parser/-/m365-spec-parser-0.3.1.tgz",
+      "integrity": "sha1-0P343A9nGfn1q19CwwxcRw1iyIw=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@apidevtools/swagger-parser": "^10.1.1",
-        "@microsoft/app-manifest": "1.0.7",
+        "@microsoft/app-manifest": "1.1.1",
         "fs-extra": "^11.2.0",
-        "js-yaml": "^4.1.0",
+        "js-yaml": "^4.3.0",
         "openapi-types": "^7.2.3",
         "swagger2openapi": "^7.0.8"
       },
@@ -5294,9 +5294,9 @@
       }
     },
     "node_modules/@microsoft/m365agentstoolkit-cli": {
-      "version": "1.1.12",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/m365agentstoolkit-cli/-/m365agentstoolkit-cli-1.1.12.tgz",
-      "integrity": "sha1-xhlCQrUHxwUlKws6KNQo+G2BcuQ=",
+      "version": "1.1.15",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/m365agentstoolkit-cli/-/m365agentstoolkit-cli-1.1.15.tgz",
+      "integrity": "sha1-UChX+eFfkVOLomi7ctU8Dui9PQk=",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -5305,13 +5305,13 @@
         "@azure/arm-subscriptions": "^5.0.0",
         "@azure/core-auth": "^1.4.0",
         "@azure/identity": "^4.13.1",
-        "@azure/msal-node": "^5.2.2",
+        "@azure/msal-node": "^5.4.0",
         "@azure/msal-node-extensions": "^1.5.25",
         "@inquirer/core": "^5.1.2",
         "@inquirer/prompts": "^7.10.1",
         "@inquirer/type": "^1.1.5",
-        "@microsoft/teamsfx-api": "0.23.15",
-        "@microsoft/teamsfx-core": "3.0.14",
+        "@microsoft/teamsfx-api": "0.24.1",
+        "@microsoft/teamsfx-core": "3.1.2",
         "ansi-escapes": "^4.3.2",
         "applicationinsights": "^1.8.10",
         "async-mutex": "^0.3.1",
@@ -5326,6 +5326,7 @@
         "node-machine-id": "^1.1.12",
         "open": "^8.2.1",
         "semver": "^7.5.4",
+        "tas-client": "^0.1.73",
         "tree-kill": "^1.2.2",
         "underscore": "^1.13.8"
       },
@@ -5415,15 +5416,15 @@
       "peer": true
     },
     "node_modules/@microsoft/teamsfx-api": {
-      "version": "0.23.15",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teamsfx-api/-/teamsfx-api-0.23.15.tgz",
-      "integrity": "sha1-u5WtgDi8RGkW0IHCmkLR/k3ZoHM=",
+      "version": "0.24.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teamsfx-api/-/teamsfx-api-0.24.1.tgz",
+      "integrity": "sha1-PeQtzsax8sgK9E4RsaaZH4XDOLY=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@azure/core-auth": "^1.4.0",
-        "@microsoft/app-manifest": "1.0.7",
+        "@microsoft/app-manifest": "1.1.1",
         "chai": "^4.3.4",
         "jsonschema": "^1.4.0",
         "neverthrow": "^3.2.0",
@@ -5431,9 +5432,9 @@
       }
     },
     "node_modules/@microsoft/teamsfx-core": {
-      "version": "3.0.14",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teamsfx-core/-/teamsfx-core-3.0.14.tgz",
-      "integrity": "sha1-9ai2++DkttDrWfeTBY1/OwuTjOQ=",
+      "version": "3.1.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@microsoft/teamsfx-core/-/teamsfx-core-3.1.2.tgz",
+      "integrity": "sha1-ClJwPJDf8K5+i6PyBlYM9XdbrKQ=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5446,16 +5447,15 @@
         "@azure/core-auth": "^1.4.0",
         "@azure/core-rest-pipeline": "^1.22.1",
         "@azure/identity": "^4.1.0",
-        "@azure/msal-node": "^2.6.6",
         "@azure/storage-blob": "^12.25.0",
         "@feathersjs/hooks": "^0.6.5",
         "@microsoft/dev-tunnels-contracts": "1.1.9",
         "@microsoft/dev-tunnels-management": "1.1.9",
         "@microsoft/kiota": "1.31.1",
-        "@microsoft/m365-spec-parser": "^0.2.14",
-        "@microsoft/teamsfx-api": "0.23.15",
+        "@microsoft/m365-spec-parser": "^0.3.1",
+        "@microsoft/teamsfx-api": "0.24.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "adm-zip": "^0.5.10",
+        "adm-zip": "^0.6.0",
         "ajv": "^8.18.0",
         "axios": "^1.8.3",
         "axios-retry": "^3.3.1",
@@ -5468,10 +5468,11 @@
         "fs-extra": "^9.1.0",
         "glob": "^13.0.0",
         "handlebars": "^4.7.7",
+        "https-proxy-agent": "^7.0.6",
         "iconv-lite": "^0.6.3",
         "ignore": "^5.1.8",
         "js-base64": "^3.6.0",
-        "js-yaml": "^4.0.0",
+        "js-yaml": "^4.3.0",
         "jsonschema": "^1.4.0",
         "klaw": "^3.0.0",
         "linkedom": "^0.18.9",
@@ -5492,38 +5493,23 @@
         "strip-bom": "^4.0.0",
         "swagger2openapi": "^7.0.8",
         "tar": "^7.4.3",
+        "tmp": "^0.2.5",
         "typedi": "^0.10.0",
-        "uuid": "^8.3.2",
+        "uuid": "^11.1.1",
         "validator": "^13.7.0",
         "xml2js": "^0.5.0",
-        "yaml": "^2.2.2"
+        "yaml": "^2.4.2"
       }
     },
-    "node_modules/@microsoft/teamsfx-core/node_modules/@azure/msal-common": {
-      "version": "14.16.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-common/-/msal-common-14.16.1.tgz",
-      "integrity": "sha1-0j7M5AgjpNA610Fg3IGdYuDAp4c=",
+    "node_modules/@microsoft/teamsfx-core/node_modules/adm-zip": {
+      "version": "0.6.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/adm-zip/-/adm-zip-0.6.0.tgz",
+      "integrity": "sha1-u8XGwzN1XpZ6Bt2YdH9DHh1To88=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
-        "node": ">=0.8.0"
-      }
-    },
-    "node_modules/@microsoft/teamsfx-core/node_modules/@azure/msal-node": {
-      "version": "2.16.3",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@azure/msal-node/-/msal-node-2.16.3.tgz",
-      "integrity": "sha1-i4BRUq14CwSNbCszsdTibXtGM2g=",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@azure/msal-common": "14.16.1",
-        "jsonwebtoken": "^9.0.0",
-        "uuid": "^8.3.0"
-      },
-      "engines": {
-        "node": ">=16"
+        "node": ">=14.0"
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/ajv": {
@@ -5570,9 +5556,9 @@
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=",
+      "version": "5.0.9",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha1-fHJDiAm1+lur9UGZofHCgaaYT88=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -5763,6 +5749,17 @@
         "office-addin-manifest": "cli.js"
       }
     },
+    "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest/node_modules/adm-zip": {
+      "version": "0.5.12",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/adm-zip/-/adm-zip-0.5.12.tgz",
+      "integrity": "sha1-h3hjKOkdVLNzWNilD5VMTNc7pgs=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
     "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest/node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -5801,6 +5798,17 @@
         }
       }
     },
+    "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-manifest/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-usage-data": {
       "version": "1.6.14",
       "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/office-addin-usage-data/-/office-addin-usage-data-1.6.14.tgz",
@@ -5816,6 +5824,17 @@
       },
       "bin": {
         "office-addin-usage-data": "cli.js"
+      }
+    },
+    "node_modules/@microsoft/teamsfx-core/node_modules/office-addin-usage-data/node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@microsoft/teamsfx-core/node_modules/path-scurry": {
@@ -6156,9 +6175,9 @@
       "peer": true
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/jose": {
-      "version": "6.2.4",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jose/-/jose-6.2.4.tgz",
-      "integrity": "sha1-ad5zRnYc0ElCxlnlJNmI/rFqSm4=",
+      "version": "6.2.8",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha1-OcFFn+XqyE6zmxYjuAd9z5ymxQY=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7056,9 +7075,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7134,9 +7153,9 @@
       }
     },
     "node_modules/@typespec/ts-http-runtime": {
-      "version": "0.3.7",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.7.tgz",
-      "integrity": "sha1-mrJ1NYmDu9MLyJUM9NxX5kcGcPM=",
+      "version": "0.3.8",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/@typespec/ts-http-runtime/-/ts-http-runtime-0.3.8.tgz",
+      "integrity": "sha1-tN7lpeeXGu3HCVO7fS2/V4P0LTg=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -7890,15 +7909,15 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.18.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/axios/-/axios-1.18.1.tgz",
-      "integrity": "sha1-1j+YY7zYk4gVyG+eKr04AYnZbf4=",
+      "version": "1.19.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha1-3fhk1MgjPA5oc3RqtZNhU30FrTk=",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "follow-redirects": "^1.16.0",
-        "form-data": "^4.0.5",
+        "form-data": "^4.0.6",
         "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
@@ -8204,9 +8223,9 @@
       "dev": true
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=",
+      "version": "1.1.18",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10283,9 +10302,9 @@
       }
     },
     "node_modules/eslint-plugin-office-addins/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -10592,9 +10611,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.1.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
-      "integrity": "sha1-ThmOuRzTM9Co3cwDZQKzYYol9Ek=",
+      "version": "3.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha1-uWy7fazk83dPWKnjsa6aSlJIcuI=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10660,9 +10679,9 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.6.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
-      "integrity": "sha1-4Jd+yAdTRuIH14g4M2Ktp8CDJK4=",
+      "version": "8.6.2",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha1-Gmx/tsX1qDiDwU8dGY/N/2AIfF0=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -10774,9 +10793,9 @@
       "peer": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha1-Oz2vnOaPQflW3wtQUTLAz86ex68=",
+      "version": "3.1.5",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
       "dev": true,
       "funding": [
         {
@@ -11354,9 +11373,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11535,9 +11554,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.32",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/hono/-/hono-4.12.32.tgz",
-      "integrity": "sha1-lInrVQfCuQVU7ngXo/l9m3VO4f8=",
+      "version": "4.13.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha1-1KYGt5KVTQemIV0SwBt89Z2gPLw=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -12147,9 +12166,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.3.1",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ip-address/-/ip-address-10.3.1.tgz",
-      "integrity": "sha1-kp+WKdFyT34bdIXOiXUvNnUzahA=",
+      "version": "10.5.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha1-/NbX3+nmhBa3y3Gv6byWCz44wTs=",
       "dev": true,
       "license": "MIT",
       "peer": true,
@@ -12832,9 +12851,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha1-0ZAFcqf3zwtfVAyDZz5gutNDZZI=",
+      "version": "4.3.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
       "dev": true,
       "funding": [
         {
@@ -13829,9 +13848,9 @@
       "peer": true
     },
     "node_modules/mocha": {
-      "version": "11.7.6",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/mocha/-/mocha-11.7.6.tgz",
-      "integrity": "sha1-674imJ0Ey7lCSjYwcyBHZiTEGjM=",
+      "version": "11.8.0",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/mocha/-/mocha-11.8.0.tgz",
+      "integrity": "sha1-kWPMWWAOwmRw9rBA4wqlGsyXPtI=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -13875,9 +13894,9 @@
       }
     },
     "node_modules/mocha/node_modules/brace-expansion": {
-      "version": "2.1.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.2.tgz",
-      "integrity": "sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=",
+      "version": "2.1.4",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha1-WJ2rEcABjQNmvmTNi/Esjb7MgyY=",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17795,6 +17814,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/tas-client": {
+      "version": "0.1.73",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/tas-client/-/tas-client-0.1.73.tgz",
+      "integrity": "sha1-Laz2hUejeYnvFVTGUQ3BCKHqenE=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "axios": "^1.6.1"
+      }
+    },
     "node_modules/terser": {
       "version": "5.39.0",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.39.0.tgz",
@@ -17922,6 +17952,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha1-JvTbEdFgHOgBLcuKeY7OHAapkFk=",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14.14"
       }
     },
     "node_modules/to-regex-range": {
@@ -18455,14 +18496,18 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha1-gNW1ztJxu5r2xEXyGhoExgbO++I=",
+      "version": "11.1.1",
+      "resolved": "https://office.pkgs.visualstudio.com/_packaging/OfficeDev/npm/registry/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha1-9tgdLhxl0Adi5eKbFsXS2ZXiCK0=",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "peer": true,
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache-lib": {


### PR DESCRIPTION
**Change Description**:
Fix the convert script to not use the private registry for the npx command

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
No.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
No.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran conversion locally.